### PR TITLE
Allow extreme race conditions to still resolve

### DIFF
--- a/shared/tools/global.py
+++ b/shared/tools/global.py
@@ -5,27 +5,27 @@
 
 	When used, ExtraGlobal will generate two threads:
 	 - A cache thread that holds references even if the source threads or functions
-	     go out of scope
+		 go out of scope
 	 - A monitoring thread that culls the cache periodically, checking what items
-	     need to be removed from expiration, or replaced/refreshed from a callback
+		 need to be removed from expiration, or replaced/refreshed from a callback
 
 	The ExtraGlobal class can not be instantiated - it is forced to be a singleton
 	  interface by the metaclass that defines it. All methods to interact with the
-	  cache is via MetaExtraGlobal's configuration. 
+	  cache is via MetaExtraGlobal's configuration.
 
-	Note that this has the side effect of not only being a singleton, 
+	Note that this has the side effect of not only being a singleton,
 	  but it also effectively can't be subclassed! Don't try to: this is
 	  not something that should have special contexts or clever instances.
 	  Treat it as a dumb key-value store, where the key can be as complicated
-	  as a two element tuple. (Anything more sophisticated lies madness.) 
+	  as a two element tuple. (Anything more sophisticated lies madness.)
 
 	To summarize:
-	           ExtraGlobal - the cache interface
-	       MetaExtraGlobal - the interface definition for the cache
+			   ExtraGlobal - the cache interface
+		   MetaExtraGlobal - the interface definition for the cache
 	  ExtraMetaExtraGlobal - the enforcer that MetaExtraGlobal defines the cache
-	                         only ever once at a time in the JVM
+							 only ever once at a time in the JVM
 
-	NOTE: This is *specifically* not thread smart! 
+	NOTE: This is *specifically* not thread smart!
 		  It's thread safe, but the practice of using global state is _not_!
 
 		  Use this to hold immutable objects that could be shared between threads.
@@ -47,33 +47,71 @@ __maintainer__ = 'Andrew Geiger'
 __email__ = 'andrew.geiger@corsosystems.com'
 
 #__all__ = ['ExtraGlobal']
-__all__ = [
-	'eg_stash',
-	'eg_access',
-	'eg_trash',
-	'eg_extend',
-	'eg_get',
-	'eg_setdefault',
-	'eg_keys',
-	'eg_iterkeys',
-	'eg_update',
-	]
+#__all__ = [
+#	'eg_stash',
+#	'eg_access',
+#	'eg_trash',
+#	'eg_extend',
+#	'eg_get',
+#	'eg_setdefault',
+#	'eg_keys',
+#	'eg_iterkeys',
+#	'eg_update',
+#	]
+
+
+
+@async(name='ExtraGlobal-RESET')
+def ExtraHardReset(interlock=None):
+	"""Performs a purge and reload of the ExtraGlobal cache.
+	
+	This clears the holding thread and restarts/rebuilds the setup.
+	"""
+	system.util.getLogger('ExtraGlobal').warn('Clearing and rebuilding ExtraGlobal cache from scratch')
+	# bring in and clear the current cache
+	from shared.tools.global import ExtraGlobal
+	# Blank out EG
+	ExtraGlobal.clear()
+	# Blank out MEG
+	type(ExtraGlobal)._initialized = False
+	type(ExtraGlobal)._CLEANUP_MONITOR = None
+	# Blank out EMEG
+	type(type(ExtraGlobal)).GLOBAL_REFERENCE = None
+	type(type(ExtraGlobal))._HOLDING_THREAD = None
+	del ExtraGlobal
+	
+	sleep(0.1)
+	
+	# ... then nuke the holding threads
+	for t in findThreads('ExtraGlobal-.*'):
+		# don't commit seppuku
+		if t is Thread.currentThread():
+			continue
+		t.interrupt()
+		
+	sleep(0.1)
+	
+	# ... and force it to reload and restart
+	from shared.tools.global import ExtraGlobal
+	ExtraGlobal.verify_holding_thread()
+
 
 class CacheEntry(object):
 	"""Hold the relevant details for an object in the cache.
 	Assumes that there is a monitoring process that will clear the item
 	  at its leisure after at least lifespan seconds past the last_used time.
 	"""
-	__slots__ = ('_obj', 
-		         'label', 'scope', 'lifespan', 
-		         '_last_time', 'callback')
+	__slots__ = ('_obj',
+				 'label', 'scope', 'lifespan',
+				 '_last_time', 'callback')
 
 	def __init__(self, obj, label, scope, lifespan, callback=None):
 		"""Set up the cache object. A callback may be given to generate a new value on expiration.
-		
+
 		Lifespan determines when death should occur.
 		 - If a callback is given, wait for the lifespan then refresh
 		 - Otherwise lifespan is the timeout for the cache entry cooling off
+		 
 		"""
 		self._obj = obj
 		self.label = label
@@ -82,7 +120,7 @@ class CacheEntry(object):
 
 		self._last_time = time()
 		self.callback = callback
-		
+
 	def update(self, obj=None):
 		"""Change the cache entry to what's in obj. Resets the last_time for expiration/refresh.
 		If nothing is provided, triggers the entry to update itself, if possible.
@@ -108,12 +146,25 @@ class CacheEntry(object):
 	def last_time(self):
 		"""Set as a property to prevent getting easily written to."""
 		return self._last_time
-		
+
 	@property
 	def time_remaining(self):
 		return max(0, self.lifespan - (time() - self._last_time))
 
-	@property 
+
+	def expire(self):
+		"""Force the cache entry to expire (may automatically refresh)."""
+		self._last_time = 1
+		
+		
+	def clear(self):
+		"""Force the cache entry to stop holding anything"""
+		self.callback = None
+		self._obj = None
+		self.expire()
+		
+
+	@property
 	def expired(self):
 		"""Returns true when the entry is past when it should be cleaned up.
 		If a garbage collector catches the referenced object, mark it dead
@@ -121,15 +172,15 @@ class CacheEntry(object):
 		# Don't cache null pointers...
 		if self._obj is None:
 			return True
-		
+
 		# If time expired...
 		if (time() - self._last_time > self.lifespan):
 			# ... check if it can be refreshed
 			if self.callback:
-				
+
 				self.refresh()
-				
-				# Either the refresh worked, or it didn't. 
+
+				# Either the refresh worked, or it didn't.
 				# If the refresh callback replaced the entry, then it'll return None
 				#   and the new entry will be fine and this one will just get GC'd by JVM,
 				#   and we want to signal to the monitor the new one is ok.
@@ -142,13 +193,13 @@ class CacheEntry(object):
 				#   then copy the object to be consistent until the GC catches self
 				if self is not gc_entry:
 					self._obj = gc_entry._obj
-					
+
 				return gc_entry.expired
-			
-			# otherwise there's nothing to fix it, so mark this entry for destruction		
+
+			# otherwise there's nothing to fix it, so mark this entry for destruction
 			else:
 				return True
-		
+
 		# Otherwise no death condition was detected.
 		return False
 
@@ -157,7 +208,7 @@ class CacheEntry(object):
 		"""Run the callback, if any was provided.
 		If the callback function does not return a value, assume the function
 		  updated the cache on its own (or not - perhaps it's a cleanup...)
-		Otherwise save the value and reset the clock. 
+		Otherwise save the value and reset the clock.
 		"""
 		if self.callback:
 			# in case of failure, mark to cull and move on
@@ -166,7 +217,7 @@ class CacheEntry(object):
 			except:
 				self._obj = None
 				return
-				
+
 			if ret_val is not None:
 				self._obj = ret_val
 				self._last_time = time()
@@ -176,7 +227,7 @@ class CacheEntry(object):
 		"""Extend the effective lifespan of the cache entry by additional_time seconds."""
 		self._last_time += additional_time
 
-	
+
 	@property
 	def key(self):
 		"""Act like a dict."""
@@ -187,11 +238,11 @@ class CacheEntry(object):
 		"""Reference this method to generate the key schema for the cache."""
 		return (scope, label)
 
-	
+
 	def __eq__(self, other):
 		"""Don't reset timer when merely checked (like in testing)"""
 		return self._obj == other
-		
+
 	def __ne__(self, other):
 		"""Don't reset timer when merely checked (like in testing)"""
 		return self._obj != other
@@ -203,6 +254,7 @@ class CacheEntry(object):
 			return '<CacheEntry [% 9.3fs] "%s" (global)>' % (time() - self._last_time, self.label,)
 
 
+
 class ExtraMetaExtraGlobal(type):
 	"""Force the MetaExtraGlobal definition to be a JVM-level global singleton object.
 
@@ -211,10 +263,10 @@ class ExtraMetaExtraGlobal(type):
 
 	NOTE: Once imported, the cache will launch a thread to keep itself in scope!
 	  This is to make sure that there is only ever one instance of this and derivative
-	  classes anywhere on the JVM. 
-	  
-	  Unlike the other threads, this GLOBAL_REFERENCE thread does NOT die when the cache empties. 
-	  
+	  classes anywhere on the JVM.
+
+	  Unlike the other threads, this GLOBAL_REFERENCE thread does NOT die when the cache empties.
+
 	  Keeping GLOBAL_REFERENCE alive prevents the class from getting regenerated as an optimization.
 	  If GLOBAL_REFERENCE is set to NONE, though, it will clear itself on its next scan.
 
@@ -225,7 +277,7 @@ class ExtraMetaExtraGlobal(type):
 	"""
 	HOLDING_THREAD_NAME = 'ExtraGlobal-Cache'
 	_HOLDING_THREAD = None
-	
+
 	GLOBAL_REFERENCE = None
 
 	# Period to check if the holding thread has been replaced or should be shut down.
@@ -260,12 +312,12 @@ class ExtraMetaExtraGlobal(type):
 
 			system.util.getLogger('ExtraGlobal').debug('Already initialized in %r as %r' % (cache_threads[0], cls.GLOBAL_REFERENCE))
 			cls.GLOBAL_REFERENCE = getFromThreadScope(cache_threads[0], 'MetaExtraGlobal')
-				
+
 		return cls.GLOBAL_REFERENCE
 
 	@staticmethod
 	def spawn_holding_thread(meg_cls, MEG_Reference):
-		"""Spin up (if needed) a thread to hold the cache. 
+		"""Spin up (if needed) a thread to hold the cache.
 		Checks if it should clear itself META_RELEVANCE_CHECK_PERIOD
 
 		The holding thread will run in perpetuity, but will die if:
@@ -277,8 +329,8 @@ class ExtraMetaExtraGlobal(type):
 			if meg_cls._HOLDING_THREAD.getState() != Thread.State.TERMINATED:
 				return
 			else:
-				meg_cls._HOLDING_THREAD = None	
-		
+				meg_cls._HOLDING_THREAD = None
+
 		existing_holding_threads = findThreads(meg_cls.HOLDING_THREAD_NAME)
 		
 		if existing_holding_threads:
@@ -286,24 +338,24 @@ class ExtraMetaExtraGlobal(type):
 			meg_cls._HOLDING_THREAD = existing_holding_threads[0]
 			meg_cls.GLOBAL_REFERENCE = MEG_Reference
 			return 
-				
+
 		system.util.getLogger('ExtraGlobal').debug('Spinning up holding thread')
-				
+
 		# Spin up the thread after a very short delay to allow final assignments to establish
 		@async(0.05, meg_cls.HOLDING_THREAD_NAME)
 		def holding_closure(MetaExtraGlobal=MEG_Reference):
 			"""Spin up a thread to ensure that MetaExtraGlobal is always in scope,
 			and only ever in scope exactly one time. If it goes out of scope
-			"""				
+			"""
 			from time import sleep
 			from java.lang import Thread
 
 			# Initialize to be self-consistent and self-referential
 			if MetaExtraGlobal.GLOBAL_REFERENCE is None:
 				MetaExtraGlobal.GLOBAL_REFERENCE = MetaExtraGlobal
-				
+
 			thisThread = Thread.currentThread()
-			
+
 			# This GLOBAL_REFERENCE thread will run forever until orphaned or killed directly.
 			while True:
 				# Wait for META_RELEVANCE_CHECK_PERIOD, but check occasionally if the monitor
@@ -344,9 +396,9 @@ class ExtraMetaExtraGlobal(type):
 						MetaExtraGlobal._cache = {}
 					system.util.getLogger('ExtraGlobal').debug('Closing holding thread: GLOBAL_REFERENCE detected as changed')
 					return
-					
+
 		meg_cls._HOLDING_THREAD = holding_closure()
-		
+
 		meg_cls.GLOBAL_REFERENCE = MEG_Reference
 
 
@@ -357,7 +409,7 @@ class MetaExtraGlobal(type):
 	NOTE: The Jython dict is based on a thread safe map class in Java. Thus _cache may be
 	  safely _accessed_ by anyone. Mutating entries will also be safe, but it also follows
 	  all the caveats of a global variable. This is why this is called *Extra*Global, as
-	  opposed to "Just a Bit Global, Like a Python Module Variable or Just Poor Planning." 
+	  opposed to "Just a Bit Global, Like a Python Module Variable or Just Poor Planning."
 
 	By default, a scope of None is "global". If a scope is provided and the key fails,
 	  the key will be tried with a scope of None as well, as a fallback.
@@ -379,7 +431,7 @@ class MetaExtraGlobal(type):
 	# Monitor (garbage collecing) thread configuraiton
 	# Period to check the cache for expired entries
 	CHECK_PERIOD = 10 # seconds
-	
+
 	# Inherited from the metaclass, copied here for reference
 	RELEVANCE_CHECK_PERIOD = 1 # second
 
@@ -389,7 +441,7 @@ class MetaExtraGlobal(type):
 	_cache = {}
 
 	_scoped_labels = {}
-	
+
 	def __new__(cls, clsname, bases, attrs):
 		"""Run when ExtraGlobal is created. Set to run once and only once."""
 		if not cls._initialized:
@@ -401,6 +453,8 @@ class MetaExtraGlobal(type):
 
 	def clear(cls):
 		"""Hard reset the cache."""
+		for entry in cls._cache.values():
+			entry.clear()
 		cls._cache.clear()
 		cls._scoped_labels.clear()
 		cls._CLEANUP_MONITOR = None
@@ -428,7 +482,7 @@ class MetaExtraGlobal(type):
 		  at a time different from the default (DEFAULT_LIFESPAN).
 
 		A callback can be provided that will be called when the object expires or when refresh is called.
-		  The callback must take no arguments (either setting the cache value itself or is a closure.) 
+		  The callback must take no arguments (either setting the cache value itself or is a closure.)
 		"""
 		assert label is not None, "Objects stashed need to have a label associated with them."
 
@@ -438,9 +492,9 @@ class MetaExtraGlobal(type):
 		cache_entry = CacheEntry(obj, label, scope, lifespan, callback)
 		cls._cache[cache_entry.key] = cache_entry
 		cls._scope_track(cache_entry.label, cache_entry.scope)
-		
+
 		system.util.getLogger('ExtraGlobal').trace('Stashed %r from %r' % (cache_entry.key, Thread.currentThread()))
-		
+
 		cls.spawn_cache_monitor()
 		return cache_entry.key
 
@@ -455,7 +509,7 @@ class MetaExtraGlobal(type):
 		except KeyError:
 			scope = None
 			cache_entry = cls._cache[CacheEntry.gen_key(label, scope)]
-				
+
 		cls.spawn_cache_monitor()
 		return cache_entry.obj
 
@@ -466,7 +520,7 @@ class MetaExtraGlobal(type):
 		del cls._cache[CacheEntry.gen_key(label, scope)]
 		system.util.getLogger('ExtraGlobal').trace('Trashed (scope:%r, label:%r) from %r' % (scope, label, Thread.currentThread()))
 		cls.spawn_cache_monitor()
-	
+
 
 	# Cache entry helpers
 
@@ -497,14 +551,14 @@ class MetaExtraGlobal(type):
 
 	@classmethod
 	def resolve(cls, reference):
-		"""Given a reference (the contents between the ExtraGlobal[...]), 
+		"""Given a reference (the contents between the ExtraGlobal[...]),
 		resolve what the user wanted.
 
 		The reference may be one of the following types:
 		 - slice:    where the format is [label:scope:lifespan]
 		 - iterable: where the format is [label, scope, lifespan]
 		 - just a label (default to "global" scope and default lifespan)
-		
+
 		Note that the lifetime only matters when using __setitem__.
 		"""
 		if isinstance(reference, slice):
@@ -518,7 +572,7 @@ class MetaExtraGlobal(type):
 			assert 1 <= len(reference) <= 3, "References must either be slices or iterables between 1 and 3 elements"
 
 			label = reference[0]
-			
+
 			if len(reference) >= 2:
 				scope = reference[1]
 			else:
@@ -538,15 +592,24 @@ class MetaExtraGlobal(type):
 
 	def verify_holding_thread(cls):
 		"""Make sure there's something to keep the references alive in case the source(s) go away."""
-		meta_cls = cls.__metaclass__
-		extra_meta_cls = meta_cls.__metaclass__
+		if cls.__name__ == 'ExtraGlobal':
+			meta_cls = cls.__metaclass__
+			extra_meta_cls = meta_cls.__metaclass__
+		elif cls.__name__ == 'MetaExtraGlobal':
+			meta_cls = cls
+			extra_meta_cls = meta_cls.__metaclass__
+		else:
+			raise TypeError('MEG.verify_holding_thread called out of context: %r (?!)' %(cls,))
+
 		# Is the holding thread missing?
 		if extra_meta_cls._HOLDING_THREAD is None:
 			extra_meta_cls.spawn_holding_thread(meta_cls, meta_cls)
-		# Is the holding thread dead?
+			
+		# Is the holding thread dead? (then cull)
 		elif extra_meta_cls._HOLDING_THREAD.getState() == Thread.State.TERMINATED:
 			extra_meta_cls._HOLDING_THREAD = None
 			extra_meta_cls.spawn_holding_thread(meta_cls, meta_cls)
+
 
 
 	def spawn_cache_monitor(cls):
@@ -560,14 +623,14 @@ class MetaExtraGlobal(type):
 		 - the class' _CLEANUP_MONITOR is cleared
 		 - the class' _CLEANUP_MONITOR no longer references the monitoring script
 		 - the cache is empty
-		
+
 		Once started, the monitor will scan all objects in the cache to determine
 		  if they should be culled. If their time is up, an attempt will be made
 		  to refresh it. If the refresh brought the object back, then it will be skipped.
 		  Otherwise the cache entry will be trashed.
 		"""
 		cls.verify_holding_thread()
-		
+
 		if cls._CLEANUP_MONITOR:
 			if cls._CLEANUP_MONITOR.getState() != Thread.State.TERMINATED:
 				return
@@ -577,10 +640,10 @@ class MetaExtraGlobal(type):
 		# Spin up the thread after a very short delay to allow final assignments to establish
 		@async(0.05, cls.CLEANUP_THREAD_NAME)
 		def monitor(cls=cls):
-			
+
 			# Initialize to be self-consistent and self-referential
 			thisThread = Thread.currentThread()
-			
+
 			while True:
 				# Wait for CHECK_PERIOD, but check occasionally if the monitor
 				# should be replaced. (Once scan starts, thread won't die until it's done.)
@@ -605,7 +668,7 @@ class MetaExtraGlobal(type):
 						entry = cls._cache[key]
 					except KeyError:
 						continue # the key has been deleted mid-scan
-					
+
 					# Check if the entry is expired
 					# (remember, the entry will refresh itself if it can, referencing the new entry if needed)
 					try:
@@ -614,16 +677,16 @@ class MetaExtraGlobal(type):
 					except:
 						del cls._cache[key]
 						cls._scope_untrack(entry.label, entry.scope)
-						
+
 		cls._CLEANUP_MONITOR = monitor()
 
 	# Convenience (dict-like) methods
-		
+
 	def __getitem__(cls, reference):
-		"""Retrieve an item from the cache. 
+		"""Retrieve an item from the cache.
 		Acts like a dictionary lookup, but can reference a scope as well.
 
-		Reference as either [label], [label:scope], or [label, scope] 
+		Reference as either [label], [label:scope], or [label, scope]
 		"""
 		label, scope, _ = cls.resolve(reference)
 		return cls.access(label, scope)
@@ -634,7 +697,7 @@ class MetaExtraGlobal(type):
 		Acts like a dictionary reference, but both a scope and a lifespan can be provided.
 
 		Reference as either [label], [label:scope], [label:scope:lifespan], [label::lifespan],
-		  or [label, scope], [label, scope, lifespan], [label, , lifespan] 
+		  or [label, scope], [label, scope, lifespan], [label, , lifespan]
 		"""
 
 		label, scope, lifespan = cls.resolve(reference)
@@ -645,13 +708,13 @@ class MetaExtraGlobal(type):
 		"""Remove an item from the cache.
 		Acts like a dictionary, but can reference a scope as well.
 
-		Reference as either [label], [label:scope], or [label, scope] 
+		Reference as either [label], [label:scope], or [label, scope]
 		"""
 		label, scope, _ = cls.resolve(reference)
 		cls.trash(label, scope)
 
 	# Additional Dict convenience methods
-	
+
 	def get(cls, label, scope=None, default=None):
 		"""Return a value without a KeyError if the reference is missing. (Like a dict)"""
 		key = CacheEntry.gen_key(label, scope)
@@ -693,51 +756,51 @@ class MetaExtraGlobal(type):
 
 	def items(cls):
 		raise NotImplementedError("Cache should not be iterated across values.")
-		
+
 	def update(cls, new_values=None, **kwargs):
 		"""Updates the cache with new_values, updating existing cache entries.
-		
+
 		Acceptable values are:
 			new_values may be a dict, where keys are references and values are replacements.
 			new_values may be a list of references to force the entries to update themselves.
 			  where references will be decoded like dict[...] references.
 			keyword arguments are all interpreted as labels and objects, with scope=None.
-			
+
 		Note that the cache entries maintain their settings, and new entries get defaults.
 		Also note that this does _not_ fail to global scope - references must be explicit
 		"""
 		if new_values is None:
 			pass
-		
+
 		elif isinstance(new_values, dict):
 			for reference, obj in new_values.items():
 				label, scope, lifespan = cls.resolve(reference)
-				
+
 				# keyword arguments override given dict, so skip and leave for kwargs handling
 				if scope is None and label in kwargs:
 					continue
-					
+
 				key = CacheEntry.gen_key(label, scope)
 				if key in cls._cache:
 					cls._cache[key].update(obj)
 				else:
 					cls.stash(obj, label, scope, lifespan)
-			
+
 		# assume an iterable of references
 		else:
 			for reference in new_values:
 				label, scope, _ = cls.resolve(reference)
-				
+
 				key = CacheEntry.gen_key(label, scope)
 				cls._cache[key].update()
-		
+
 		for local, obj in kwargs.items():
 			key = CacheEntry.gen_key(label, scope=None)
 			if key in cls._cache:
 				cls._cache[key].update(obj)
 			else:
 				cls.stash(obj, local)
-		
+
 
 	def __contains__(cls, reference):
 		if reference in cls._cache:
@@ -746,8 +809,8 @@ class MetaExtraGlobal(type):
 
 		if CacheEntry.gen_key(label, scope) in cls._cache:
 			return True
-		
-		return False  
+
+		return False
 
 
 	def __iter__(cls):
@@ -758,10 +821,31 @@ class MetaExtraGlobal(type):
 		return '<%s with %d items>' % (cls.__name__, len(cls._cache))
 
 
-class ExtraGlobal(MetaSingleton):
-	"""This is a singleton implementation of the cache. It exists without instances."""
-	__metaclass__ = ExtraMetaExtraGlobal.GLOBAL_REFERENCE
+try:
+	class ExtraGlobal(MetaSingleton):
+		"""This is a singleton implementation of the cache. It exists without instances."""
+		__metaclass__ = ExtraMetaExtraGlobal.GLOBAL_REFERENCE
+except TypeError:
+	# In extreme race conditions, the ExtraMetaExtraGlobal.GLOBAL_REFERENCE may not be
+	# the same as the one that created MetaExtraGlobal in this scope.
+	# If so, we'll find the holding thread and pull that instance out and
+	# replace all references to that one.
+	
+	# NOTE: We're in a race condition!
+	# let the first to post win so we can piggyback on them
+	sleep(0.06) 
+	
+	_recover_holding_threads = findThreads(ExtraMetaExtraGlobal.HOLDING_THREAD_NAME)
+	assert _recover_holding_threads, 'ExtraGlobal Failed compiling sanity check as well as initialization!'
+	
+	# heuristic: lower id implies older - use the oldest
+	_recover_holding_threads.sort(key=lambda t: t.getId())
+	
+	ExtraMetaExtraGlobal = getFromThreadScope(_recover_holding_threads[0], 'ExtraMetaExtraGlobal')
+	MetaExtraGlobal = ExtraMetaExtraGlobal.GLOBAL_REFERENCE
+	ExtraGlobal = MetaExtraGlobal._initialized
 
+ExtraGlobal.verify_holding_thread()	
 
 ##==========================================================================
 ## Global access, in case class access is undesired
@@ -775,19 +859,19 @@ class ExtraGlobal(MetaSingleton):
 #		__metaclass__ = ExtraMetaExtraGlobal.GLOBAL_REFERENCE
 #
 #	return CacheAccess
-#	
-#	
+#
+#
 #def eg_stash(obj, label=None, scope=None, lifespan=None, callback=None):
 #	"""Add an object to the cache.  Label will be how it's retrieved, with an optional scope
 #	  in case multiple labels are the same in differing contexts.
-#	
+#
 #	Object in cache for the label in that scope will be replaced if it already exists!
-#	
+#
 #	A lifetime can be given if the object should be cleared out of the cache
 #	  at a time different from the default (DEFAULT_LIFESPAN).
-#	
+#
 #	A callback can be provided that will be called when the object expires or when refresh is called.
-#	  The callback must take no arguments (either setting the cache value itself or is a closure.) 
+#	  The callback must take no arguments (either setting the cache value itself or is a closure.)
 #	"""
 #	shared.tools.global.ExtraGlobal.stash(obj, label, scope, lifespan, callback)
 #
@@ -824,13 +908,13 @@ class ExtraGlobal(MetaSingleton):
 #
 #def eg_update(new_values=None, **kwargs):
 #	"""Updates the cache with new_values, updating existing cache entries.
-#	
+#
 #	Acceptable values are:
 #		new_values may be a dict, where keys are references and values are replacements.
 #		new_values may be a list of references to force the entries to update themselves.
 #		  where references will be decoded like dict[...] references.
 #		keyword arguments are all interpreted as labels and objects, with scope=None.
-#		
+#
 #	Note that the cache entries maintain their settings, and new entries get defaults.
 #	Also note that this does _not_ fail to global scope - references must be explicit
 #	"""


### PR DESCRIPTION
In some extreme edge cases, it's possible for the metaclass to resolve to the wrong one on start, leading to a type error that can't be resolved. The end class def for ExtraGlobal goes into a repair/recovery routine and extracts MetaExtraGlobal to use the already initialized class of ExtraGlobal.

Also includes ExtraHardReset, which resets extra hard. It does _not_ cause MEG to be regenerated, but it does force as much as possible to re-resolved.